### PR TITLE
Fix: login/registration auto-nav on success

### DIFF
--- a/app/src/main/java/com/initiatetech/initiate_news/MainActivity.kt
+++ b/app/src/main/java/com/initiatetech/initiate_news/MainActivity.kt
@@ -15,25 +15,29 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
+
+        // Initially displays the NewsFragment automatically
+        supportFragmentManager.beginTransaction().replace(R.id.main_content, NewsFragment()).commit()
+
         binding.bottomNavigation.setOnNavigationItemSelectedListener {
             when(it.itemId){
                 R.id.action_home ->{
-                    var f = NewsFragment()
+                    val f = NewsFragment()
                     supportFragmentManager.beginTransaction().replace(R.id.main_content,f).commit()
                     return@setOnNavigationItemSelectedListener true
                 }
                 R.id.action_search ->{
-                    var f = SearchFragment()
+                    val f = SearchFragment()
                     supportFragmentManager.beginTransaction().replace(R.id.main_content,f).commit()
                     return@setOnNavigationItemSelectedListener true
                 }
                 R.id.action_friend ->{
-                    var f = FriendFragment()
+                    val f = FriendFragment()
                     supportFragmentManager.beginTransaction().replace(R.id.main_content,f).commit()
                     return@setOnNavigationItemSelectedListener true
                 }
                 R.id.action_account ->{
-                    var f = UserFragment()
+                    val f = UserFragment()
                     supportFragmentManager.beginTransaction().replace(R.id.main_content,f).commit()
                     return@setOnNavigationItemSelectedListener true
                 }

--- a/app/src/main/java/com/initiatetech/initiate_news/login/LoginActivity.kt
+++ b/app/src/main/java/com/initiatetech/initiate_news/login/LoginActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.button.MaterialButton
+import com.initiatetech.initiate_news.MainActivity
 import com.initiatetech.initiate_news.R
 import com.initiatetech.initiate_news.register.RegisterActivity
 import com.initiatetech.initiate_news.repository.UserRepository
@@ -60,6 +61,7 @@ class LoginActivity : AppCompatActivity() {
             when (status) {
                 UserViewModel.LoginStatus.SUCCESS -> {
                     Toast.makeText(this, "Login successful", Toast.LENGTH_SHORT).show()
+                    navigateToMainActivity()
                 }
                 UserViewModel.LoginStatus.FAILURE -> {
                     Toast.makeText(this, "Login failed", Toast.LENGTH_SHORT).show()
@@ -73,6 +75,11 @@ class LoginActivity : AppCompatActivity() {
 
     private fun navigateToRegisterActivity() {
         val intent = Intent(this, RegisterActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun navigateToMainActivity() {
+        val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/initiatetech/initiate_news/register/RegisterActivity.kt
+++ b/app/src/main/java/com/initiatetech/initiate_news/register/RegisterActivity.kt
@@ -1,6 +1,8 @@
 package com.initiatetech.initiate_news.register
 
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.util.Patterns
 import android.widget.EditText
 import android.widget.Toast
@@ -9,6 +11,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.button.MaterialButton
 import com.initiatetech.initiate_news.R
+import com.initiatetech.initiate_news.login.LoginActivity
 import com.initiatetech.initiate_news.repository.UserRepository
 import com.initiatetech.initiate_news.viewmodel.UserViewModel
 
@@ -18,6 +21,7 @@ class RegisterActivity : AppCompatActivity() {
     private lateinit var emailEditText: EditText
     private lateinit var passwordEditText: EditText
     private lateinit var registerButton: MaterialButton
+    private lateinit var cancelButton: MaterialButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,9 +34,15 @@ class RegisterActivity : AppCompatActivity() {
         emailEditText = findViewById(R.id.editTextEmail)
         passwordEditText = findViewById(R.id.editTextPassword)
         registerButton = findViewById(R.id.buttonRegister)
+        cancelButton = findViewById(R.id.buttonCancelRegister)
 
         registerButton.setOnClickListener {
             registerUser()
+        }
+
+        cancelButton.setOnClickListener {
+            Log.d("Registration", "Cancelled")
+            navigateToLoginActivity()
         }
 
         observeRegistrationStatus()
@@ -59,6 +69,7 @@ class RegisterActivity : AppCompatActivity() {
             when (status) {
                 UserViewModel.RegistrationStatus.SUCCESS -> {
                     Toast.makeText(this, "Registration successful", Toast.LENGTH_SHORT).show()
+                    navigateToLoginActivity()
                 }
                 UserViewModel.RegistrationStatus.FAILURE -> {
                     Toast.makeText(this, "Registration failed", Toast.LENGTH_SHORT).show()
@@ -68,5 +79,11 @@ class RegisterActivity : AppCompatActivity() {
                 }
             }
         })
+    }
+
+    private fun navigateToLoginActivity() {
+        val intent = Intent(this, LoginActivity::class.java)
+        startActivity(intent)
+        Log.d("Registration", "navigated to login")
     }
 }

--- a/app/src/main/java/com/initiatetech/initiate_news/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/initiatetech/initiate_news/viewmodel/UserViewModel.kt
@@ -44,12 +44,14 @@ class UserViewModel(private val userRepository: UserRepository) : ViewModel() {
 
     fun registerUser(email: String, password: String) {
         val newUser = User(email, password) // Corrected to create a new User instance
-
+        Log.d("Registration", "Start")
         userRepository.registerUser(newUser).enqueue(object : Callback<ApiResponse> { // Corrected to pass newUser
             override fun onResponse(call: Call<ApiResponse>, response: Response<ApiResponse>) {
                 if (response.isSuccessful && response.body()?.isSuccess == true) {
+                    Log.d("Registration", "success")
                     _registrationStatus.value = RegistrationStatus.SUCCESS
                 } else {
+                    Log.d("Registration", "fail")
                     _registrationStatus.value = RegistrationStatus.FAILURE
                 }
             }

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -32,4 +32,14 @@
         android:layout_margin="16dp"
         app:cornerRadius="20dp"/>
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonCancelRegister"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Cancel"
+        android:layout_below="@id/buttonRegister"
+        android:layout_margin="16dp"
+        app:cornerRadius="20dp"
+        android:backgroundTint="@color/SecondPrimary"/>
+
 </RelativeLayout>


### PR DESCRIPTION
- Added cancel registration button that returns user to login screen
- Registration navigates back to login screen on success
- Login screen navigates to main activity on success
- NewsFragment is initially loaded in main activity
- Added some new logs for registration start, success, and fail to match login
- Also added log message for registration cancel and navigation to login