### PR TITLE
feat: Added validation to check if a new keyword has news already or not

### DIFF
--- a/app/src/main/java/com/initiatetech/initiate_news/fragment/NewsFragment.kt
+++ b/app/src/main/java/com/initiatetech/initiate_news/fragment/NewsFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.initiatetech.initiate_news.R
 import com.initiatetech.initiate_news.databinding.FragmentNewsBinding
 import com.initiatetech.initiate_news.repository.KeywordRepository
+import com.initiatetech.initiate_news.repository.NewsRepository
 import com.initiatetech.initiate_news.viewmodel.KeywordViewModel
 
 // TODO: Rename parameter arguments, choose names that match
@@ -56,7 +57,7 @@ class NewsFragment : Fragment() {
         _binding = FragmentNewsBinding.inflate(inflater, container, false)
 
         // Initialize the ViewModel
-        val factory = KeywordViewModel.KeywordViewModelFactory(KeywordRepository(), context)
+        val factory = KeywordViewModel.KeywordViewModelFactory(KeywordRepository(), NewsRepository(), context)
         viewModel = ViewModelProvider(this, factory).get(KeywordViewModel::class.java)
 
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/initiatetech/initiate_news/fragment/SearchFragment.kt
+++ b/app/src/main/java/com/initiatetech/initiate_news/fragment/SearchFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.initiatetech.initiate_news.databinding.FragmentSearchBinding
 import com.initiatetech.initiate_news.repository.KeywordRepository
+import com.initiatetech.initiate_news.repository.NewsRepository
 import com.initiatetech.initiate_news.viewmodel.KeywordViewModel
 
 
@@ -37,7 +38,7 @@ class SearchFragment : Fragment() {
         _binding = FragmentSearchBinding.inflate(inflater, container, false)
 
         // Initialize View Model
-        val factory = KeywordViewModel.KeywordViewModelFactory(KeywordRepository(), context)
+        val factory = KeywordViewModel.KeywordViewModelFactory(KeywordRepository(), NewsRepository(), context)
         viewModel = ViewModelProvider(this, factory).get(KeywordViewModel::class.java)
 
         return binding.root


### PR DESCRIPTION
Added validation logic and API call to check if a user's new keyword already has news for it or not.

If it has no news, there is a TODO to implement code in order to generate news for the keyword upon being added